### PR TITLE
switch from travis to github actions & spec for actual ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Test
+on:
+  pull_request: {}
+  push: { branches: ['master'] }
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - 2.7
+          - '3.0'
+          - 3.1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run rspec
+        run: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-rvm:
-  - "1.8.7"
-  - "1.9.2"
-  - "1.9.3"
-  - "jruby-18mode"
-  - "jruby-19mode"
-  - "ree"
-  - "2.0.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# payu [![Gem Version](https://badge.fury.io/rb/payu.png)](http://badge.fury.io/rb/payu) [![Build Status](https://api.travis-ci.org/ronin/payu.png?branch=master)](http://travis-ci.org/ronin/payu) [![Code Climate](https://codeclimate.com/github/ronin/payu.png)](https://codeclimate.com/github/ronin/payu)
-
+# payu [![Gem Version](https://badge.fury.io/rb/payu.png)](http://badge.fury.io/rb/payu) ![Build Status](https://github.com/ronin/payu/actions/workflows/test.yml/badge.svg?branch=master) [![Code Climate](https://codeclimate.com/github/ronin/payu.png)](https://codeclimate.com/github/ronin/payu)
 
 Simple library for accepting payments via PayU.
 


### PR DESCRIPTION
Hello!

I noticed that the last https://travis-ci.org/github/ronin/payu pipeline has been launched for a very long time and for ruby versions that are not supported https://endoflife.date/ruby

I made an update and now the tests are run on the current versions of ruby

if you need to add something, I can make changes to the PR