### PR TITLE
Fixnum to Integer

### DIFF
--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -54,7 +54,7 @@ describe 'Transaction' do
     )
 
     transaction.session_id.should_not be_nil
-    transaction.session_id.class.should == Fixnum
+    transaction.session_id.class.should == Integer
   end
 
   it 'should not overwrite passed session_id' do
@@ -85,7 +85,7 @@ describe 'Transaction' do
         )
 
         transaction.ts.should_not be_nil
-        transaction.ts.class.should == Fixnum
+        transaction.ts.class.should == Integer
 
         signature_keys = [1, '123', 'abcde', 100, 'Description', 'John', 'Doe', 'john.doe@example.org', '127.0.0.1', transaction.ts, '3d91f185cacad7c1d830d1472dfaacc5']
         expected_signature = Digest::MD5.hexdigest(signature_keys.join)


### PR DESCRIPTION
[Unify Fixnum and Bignum into Integer](https://bugs.ruby-lang.org/issues/12005)

Though [ISO/IEC 30170:2012](http://www.iso.org/iso/iso_catalogue/catalogue_tc/catalogue_detail.htm?csnumber=59579) doesn’t specify details of the Integer class, Ruby had two visible Integer classes: Fixnum and Bignum. Ruby 2.4 unifies them into Integer. All C extensions which touch the Fixnum or Bignum class need to be fixed. 

[source](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/) 